### PR TITLE
Add support for upgrading firmware via `.p1fw` file

### DIFF
--- a/lg69t/README.md
+++ b/lg69t/README.md
@@ -20,13 +20,18 @@ And download the latest firmware package from [Point One's Developer Portal](htt
 
 To update the Application and GNSS firmware, you must use UART1 (`Standard COM Port` for Windows, typically `/dev/ttyUSB1` in Linux for P1SDK).
 
-To update via `p1fw` path:
+**To update via `p1fw` path:**
 
 ```
 python3 firmware_tool.py --port=/dev/ttyUSB1 --p1fw=/path/to/quectel-lg69t-am-0.XX.0.p1fw
 ```
 
-To update via individual `.bin` files:
+Replace `/dev/ttyUSB1` with the serial port connected to the device via UART1 (use the appropriate COM port number in Windows, e.g., `Standard COM Port`).
+
+Replace `/path/to/quectel-lg69t-am-0.XX.0.p1fw` with the path to the `p1fw` file. If the `p1fw` was decompressed,
+the resulting directory may be passed here as well.
+
+**To update via individual `.bin` files:**
 
 ```
 python3 firmware_tool.py --port=/dev/ttyUSB1 --app=/path/to/quectel-lg69t-am-0.XX.0_upg.bin
@@ -35,8 +40,7 @@ python3 firmware_tool.py --port=/dev/ttyUSB1 --gnss=/path/to/lg69t_teseo_A.B.CC.
 
 Replace `/dev/ttyUSB1` with the serial port connected to the device via UART1 (use the appropriate COM port number in Windows, e.g., `Standard COM Port`).
 
-If upgrading via a `p1fw` file, replace `/path/to/quectel-lg69t-am-0.XX.0.p1fw` with the path to the `p1fw` file. If upgrading via
-individual application and GNSS firmware binary files, replace `/path/to/quectel-lg69t-am-0.XX.0_upg.bin` and `/path/to/lg69t_teseo_A.B.CC.D_sta.bin` with the path to the application image and GNSS image files respectively. The device must be rebooted after each command is executed successfully.
+Replace `/path/to/quectel-lg69t-am-0.XX.0_upg.bin` and `/path/to/lg69t_teseo_A.B.CC.D_sta.bin` with the path to the application image and GNSS image files respectively. The device must be rebooted after each command is executed successfully.
 
 ## Considerations
 

--- a/lg69t/README.md
+++ b/lg69t/README.md
@@ -18,7 +18,15 @@ And download the latest firmware package from [Point One's Developer Portal](htt
 
 ## Application and GNSS
 
-To update the Application and GNSS firmware, you must use UART1 (`Standard COM Port` for Windows, typically `/dev/ttyUSB1` in Linux for P1SDK):
+To update the Application and GNSS firmware, you must use UART1 (`Standard COM Port` for Windows, typically `/dev/ttyUSB1` in Linux for P1SDK).
+
+To update via `p1fw` path:
+
+```
+python3 firmware_tool.py --port=/dev/ttyUSB1 --p1fw=/path/to/quectel-lg69t-am-0.XX.0.p1fw
+```
+
+To update via individual `.bin` files:
 
 ```
 python3 firmware_tool.py --port=/dev/ttyUSB1 --app=/path/to/quectel-lg69t-am-0.XX.0_upg.bin
@@ -27,7 +35,8 @@ python3 firmware_tool.py --port=/dev/ttyUSB1 --gnss=/path/to/lg69t_teseo_A.B.CC.
 
 Replace `/dev/ttyUSB1` with the serial port connected to the device via UART1 (use the appropriate COM port number in Windows, e.g., `Standard COM Port`).
 
-Replace `/path/to/quectel-lg69t-am-0.XX.0_upg.bin` and `/path/to/lg69t_teseo_A.B.CC.D_sta.bin` with the path to the application image and GNSS image files respectively. The device must be rebooted after each command is executed successfully.
+If upgrading via a `p1fw` file, replace `/path/to/quectel-lg69t-am-0.XX.0.p1fw` with the path to the `p1fw` file. If upgrading via
+individual application and GNSS firmware binary files, replace `/path/to/quectel-lg69t-am-0.XX.0_upg.bin` and `/path/to/lg69t_teseo_A.B.CC.D_sta.bin` with the path to the application image and GNSS image files respectively. The device must be rebooted after each command is executed successfully.
 
 ## Considerations
 
@@ -43,4 +52,3 @@ To program the bootloader:
 - Release the BOOT button after the device is powered up.
 - Run `stm32loader -p /dev/ttyUSB0 -e -w -v -a 0x08000000 quectel-bootloader-A.B.C.bin`
 - Press the RESET button to complete the process.
-

--- a/lg69t/firmware_tool.py
+++ b/lg69t/firmware_tool.py
@@ -219,7 +219,7 @@ def Upgrade(port_name: str, bin_file: typing.BinaryIO, upgrade_type: UpgradeType
         print('Sending Data')
         if send_firmware(ser, class_id, firmware_data) is True:
             print('Update Success')
-            if not should_send_reboot:
+            if not send_reboot(ser):
                 print('Please reboot the device...')
             return True
         else:

--- a/lg69t/firmware_tool.py
+++ b/lg69t/firmware_tool.py
@@ -318,9 +318,13 @@ def main():
             if os.path.isdir(p1fw_path):
                 p1fw = p1fw_path
             else:
-                p1fw = ZipFile(p1fw_path, 'r')
+                try:
+                    p1fw = ZipFile(p1fw_path, 'r')
+                except:
+                    print('Provided path does not lead to a zip file or a directory.')
+                    sys.exit(2)
         else:
-            print("Provided path %s not found." % p1fw_path)
+            print('Provided path %s not found.' % p1fw_path)
             sys.exit(2)
 
     if p1fw:

--- a/lg69t/firmware_tool.py
+++ b/lg69t/firmware_tool.py
@@ -195,7 +195,7 @@ def Upgrade(port_name: str, bin_file, upgrade_type: UpgradeType, should_send_reb
         if not get_response(class_id, MSG_ID_FIRMWARE_ADDRESS, ser):
             return False
 
-        firmware_data = bin_file.read()
+        firmware_data = bin_file
 
         print('Sending Firmware Info')
         if upgrade_type == UpgradeType.GNSS:
@@ -308,7 +308,7 @@ def main():
 
     if gnss_bin_fd:
         print('Upgrading GNSS...')
-        if not Upgrade(port_name, gnss_bin_path, UpgradeType.GNSS, should_send_reboot):
+        if not Upgrade(port_name, gnss_bin_fd, UpgradeType.GNSS, should_send_reboot):
             sys.exit(2)
 
     if app_bin_fd is not None:
@@ -319,7 +319,7 @@ def main():
 
     if app_bin_fd:
         print('Upgrading App...')
-        if not Upgrade(port_name, app_bin_path, UpgradeType.APP, should_send_reboot):
+        if not Upgrade(port_name, app_bin_fd, UpgradeType.APP, should_send_reboot):
             sys.exit(2)
 
 

--- a/lg69t/firmware_tool.py
+++ b/lg69t/firmware_tool.py
@@ -44,13 +44,16 @@ TAIL = b'\x55'
 
 def send_reboot(ser: Serial, timeout=10):
     start_time = time.time()
+    last_send_time = 0
     reset_message = ResetRequest(ResetRequest.REBOOT_NAVIGATION_PROCESSOR)
     encoder = FusionEngineEncoder()
     data = encoder.encode_message(reset_message)
-    ser.write(data)
-    ser.flush()
     decoder = FusionEngineDecoder()
     while time.time() < start_time + timeout:
+        if time.time() > last_send_time + 0.5:
+            ser.write(data)
+            ser.flush()
+            last_send_time = time.time()
         messages = decoder.on_data(ser.read_all())
         for header, payload in messages:
             if header.message_type == CommandResponseMessage.MESSAGE_TYPE:


### PR DESCRIPTION
User may pass in a compressed `.p1fw` file (this is the expected input), _or_ an uncompressed directory. It is expected that the provided `.p1fw` file contains both the application and the GNSS firmware. In the event that a user passes in a valid `.p1fw` file, _and_ an individual binary file containing application or GNSS firmware, the contents of the `.p1fw` file will be used and the individual binary file will be ignored.