### PR TITLE
Require FusionEngine 1.19.0.

### DIFF
--- a/lg69t/requirements.txt
+++ b/lg69t/requirements.txt
@@ -1,2 +1,2 @@
-fusion-engine-client>=1.18.0
+fusion-engine-client>=1.19.0
 pyserial


### PR DESCRIPTION
The OS version string name change in 1.19.0 is not backwards compatible.